### PR TITLE
Fix error when using eshell-vterm with TRAMP

### DIFF
--- a/eshell-vterm.el
+++ b/eshell-vterm.el
@@ -51,7 +51,7 @@ allowed.  In case ARGS is nil, a new VTerm session is created."
              (term-buf (generate-new-buffer
                         (concat "*" (file-name-nondirectory program) "*")))
              (eshell-buf (current-buffer))
-             (vterm-shell (concat program " " args)))
+             (vterm-shell (concat (file-local-name program) " " args)))
         (save-current-buffer
           (switch-to-buffer term-buf)
           (vterm-mode)


### PR DESCRIPTION
`eshell-vterm-exec-visual` fails when the current directory in eshell is a tramp path, as the command in `vterm-shell` contains the remote path component when it should not.

To reproduce, run the following commands in eshell:
```
cd /sudo::/
(eshell-vterm-exec-visual "ls")
```

The fix is to not include the remote path component in `vterm-shell`.