### PR TITLE
Fix vterm's command override for remote connections

### DIFF
--- a/eshell-vterm.el
+++ b/eshell-vterm.el
@@ -56,7 +56,9 @@ allowed.  In case ARGS is nil, a new VTerm session is created."
                                   " " args)))
         (save-current-buffer
           (switch-to-buffer term-buf)
-          (vterm-mode)
+          (cl-letf (((symbol-function 'vterm--get-shell)
+                     (lambda () vterm-shell)))
+            (vterm-mode))
           (setq-local eshell-parent-buffer eshell-buf)
           (let ((proc (get-buffer-process term-buf)))
             (if (and proc (eq 'run (process-status proc)))


### PR DESCRIPTION
Running a visual command in a remote directory results in a vterm buffer that executes a shell instead of the desired command. This is because vterm overrides the command variable (vterm-shell) for remote directories.
Inhibit this behavior for eshell-vterm.

This is broken since:
https://github.com/akermu/emacs-libvterm/commit/90680707f3af76d3b1e78ae68ac95f9da8c84cbe
or earlier if you have customized `vterm-tramp-shells`:
https://github.com/akermu/emacs-libvterm/commit/b1a6d1ce566b07483252929fd98eb07b37609ddb
